### PR TITLE
10014 Handlungen am gleichen Ort zusammenlegen

### DIFF
--- a/ausgabe.pl
+++ b/ausgabe.pl
@@ -19,6 +19,7 @@ printMinSammlungForm(SammelSet, Vorgaenge, MinimalSammelZahl, GesamtWertSammlung
 			  </caption>
 			  <tr>
 			    <th scope="col">Anweisung&nbsp;</th>
+			    <th scope="col">Operation&nbsp;</th>
 			    <th scope="col">Ergebnis&nbsp;</th>
 			  </tr>~n'),
 	ausgabeVorgaenge(Vorgaenge),
@@ -90,6 +91,7 @@ gebeAus(Vorgaenge) :-
 	gebeKomponenteAus(Komponenten),
 	format(' aus'),
 	format('.~n&nbsp;</td>'),
+	format('<td>~k~n&nbsp;</td>~n', Operation),
 	format('<td>'),
 	format('~k ', ProduktAnzahl),
 	format('Einheiten ~k', Produkt),
@@ -106,8 +108,8 @@ gebeAus(Vorgaenge) :-
 	format('<td>'),
 	format('Das ~k ist bekannt.', Produkt),
 	format('~n&nbsp;</td>'),
-	format('<td>'),
-	format('~n&nbsp;</td>'),
+	format('<td>&nbsp;</td>~n'),
+	format('<td>~n&nbsp;</td>'),
 	format('</tr>~n'),
 	gebeAus(Rest),
 	!.		
@@ -122,6 +124,7 @@ gebeAus(Vorgaenge) :-
 	format('Einheiten ~k mit ', Produkt),
 	format('~k', Operation),
 	format('.~n&nbsp;</td>'),
+	format('<td>~k~n&nbsp;</td>~n', Operation),
 	format('<td>'),
 	format('~k ', WandelAnz),
 	format('Einheiten ~k', Produkt),
@@ -139,8 +142,10 @@ gebeAus(Vorgaenge) :-
 	format('Bitte ~k Sie nach ', Operation),
 	format('~k.', Nach),
 	format('~n&nbsp;</td>'),
+	format('<td>~k~n&nbsp;</td>~n', Operation),
 	format('<td>'),
-	format('~k', Produkt),
+	format('in ~k ', Nach),
+	format('~k~n&nbsp;', Produkt),
 	format('</tr>~n'),
 	gebeAus(Rest),
 	!.		

--- a/logistik.pl
+++ b/logistik.pl
@@ -1,35 +1,65 @@
 :- module(logistik, [logistikOptimierungReisen/2]).
 
-/* Minimalversion ohne Funktion als Platzhalter */
+/* Minimalversion ohne Funktion als Platzhalter */	
 logistikOptimierungReisen(Vorgaenge, OptimierteVorgaenge) :-
 	/* gleiche Vorgänge, die mehrfach vorkommen, zu einer mit erhöhter Stückzahl machen bei gleicher Reihenfolge */
 	/* summarischer Satz ist an Position des ersten Auftretens des Vorganges */
 	include(isSammlung, Vorgaenge, Sammlungen),
-	group(Sammlungen, [], SammlungenGruppiert),
+	gruppierenUndSummieren(Sammlungen, [], SammlungenGruppiert),
+	gruppiereSammelvorgaengeNachOrt(SammlungenGruppiert, SammlungenGruppiert1),
 	include(isBekannt, Vorgaenge, Bekannte),
-	append(SammlungenGruppiert, Bekannte, OptimierteVorgaenge0),
+	append(SammlungenGruppiert1, Bekannte, OptimierteVorgaenge0),
 	include(isWandlung, Vorgaenge, Wandlungen),
-	group(Wandlungen, [], WandlungenGruppiert),
+	gruppierenUndSummieren(Wandlungen, [], WandlungenGruppiert),
 	append(OptimierteVorgaenge0, WandlungenGruppiert, OptimierteVorgaenge).
-
-isWandlung(Vorgang) :-
-	Vorgang = [_, [Operation, _], _, [_, _]],
-	rezept:wandelAktion(Operation, _).
 
 isSammlung(Vorgang) :-
 	Vorgang = [_, [Operation, _], _, [_, _]],
 	Operation \= bekannt,
-	sammeln:sammelAktion(Operation, _).
+	sammeln:sammelAktion(Operation, _),
+	!.
 
-isBekannt(Vorgang) :-
-	Vorgang = [_, [Operation, _], _, [_, _]],
-	Operation = bekannt.
+gruppiereSammelvorgaengeNachOrt(Vorgaenge, OptimierteVorgaenge) :-
+	dict_create(DictOrtVorgaenge, 'OrtVorgaenge', []),
+	inDictEinsortieren(DictOrtVorgaenge, Vorgaenge, DictGefuellt),
+	findall(AKey, get_dict(AKey, DictGefuellt, _)	, Keys),
+	ausDictSammeln(DictGefuellt, Keys, [], OptimierteVorgaenge),
+	!.
+		
+inDictEinsortieren(DictOrtVorgaenge, Vorgaenge, DictGefuellt) :-
+	Vorgaenge = [],
+	DictOrtVorgaenge = DictGefuellt.
 	
-group(Vorgaenge, BisherGruppiert, Gruppiert) :-
+inDictEinsortieren(DictOrtVorgaenge, Vorgaenge, DictGefuellt) :-
+	Vorgaenge = [Vorgang | RestVorgaenge],
+	reisen:vorgangsOrt(_, Vorgang, VorgangsOrt),
+	insertOrAppend(VorgangsOrt, [Vorgang], DictOrtVorgaenge, DictOrtVorgaenge1),
+	inDictEinsortieren(DictOrtVorgaenge1, RestVorgaenge, DictGefuellt).
+		
+insertOrAppend(Key, Val, Dict, DictDanach) :-
+	get_dict(Key, Dict, Val0),
+	append(Val, Val0, Val1),
+	put_dict(Key, Dict, Val1, DictDanach).
+	
+insertOrAppend(Key, Val, Dict, DictDanach) :-
+	put_dict(Key, Dict, Val, DictDanach).
+	
+ausDictSammeln(_, Keys, OptimierteVorgaengeBisher, OptimierteVorgaenge) :-
+	Keys = [],
+	OptimierteVorgaengeBisher = OptimierteVorgaenge. 
+
+ausDictSammeln(DictGefuellt, Keys, OptimierteVorgaengeBisher, OptimierteVorgaenge) :-
+	Keys = [ Key | RestKeys ],
+	get_dict(Key, DictGefuellt, OptimierteVorgaenge0),
+	append(OptimierteVorgaengeBisher, OptimierteVorgaenge0, OptimierteVorgaenge1),
+	ausDictSammeln(DictGefuellt, RestKeys, OptimierteVorgaenge1, OptimierteVorgaenge).
+	
+
+gruppierenUndSummieren(Vorgaenge, BisherGruppiert, Gruppiert) :-
 	Vorgaenge = [],
 	BisherGruppiert = Gruppiert.
 	 
-group(Vorgaenge, BisherGruppiert, Gruppiert) :-
+gruppierenUndSummieren(Vorgaenge, BisherGruppiert, Gruppiert) :-
 	length(Vorgaenge, Len),
 	Len > 1,
 	Vorgaenge = [SuchVorgang | _],
@@ -47,14 +77,14 @@ group(Vorgaenge, BisherGruppiert, Gruppiert) :-
 	selectchk(SuchVorgang, Vorgaenge, VorgaengeDanach0),
 	selectchk(VergleichsVorgang, VorgaengeDanach0, VorgaengeDanach1),
 	append([SummenVorgang], VorgaengeDanach1, VorgaengeDanach),
-	group(VorgaengeDanach, BisherGruppiert, Gruppiert),
+	gruppierenUndSummieren(VorgaengeDanach, BisherGruppiert, Gruppiert),
 	!.
 
-group(Vorgaenge, BisherGruppiert, Gruppiert) :-
+gruppierenUndSummieren(Vorgaenge, BisherGruppiert, Gruppiert) :-
 	Vorgaenge = [SuchVorgang | _],
 	selectchk(SuchVorgang, Vorgaenge, VorgaengeDanach),
 	append(BisherGruppiert, [SuchVorgang], BisherGruppiertDanach),
-	group(VorgaengeDanach, BisherGruppiertDanach, Gruppiert),
+	gruppierenUndSummieren(VorgaengeDanach, BisherGruppiertDanach, Gruppiert),
 	!.
 	
 gleicheElementeEnthalten(SuchStoffListe, VergleichsStoffListe) :-
@@ -72,4 +102,13 @@ addiereVorgangsWerte(SuchVorgang, VergleichsVorgang, SummenVorgang) :-
 	SummenProduktZahl is ProduktZahl1 + ProduktZahl2,
 	SummenVorgang = [SummenAnzahl,[Operation, RaffinierZeit], Komponenten, [SummenProduktZahl, Produkt]].
 	
+isBekannt(Vorgang) :-
+	Vorgang = [_, [Operation, _], _, [_, _]],
+	Operation = bekannt,
+	!.
+	
+isWandlung(Vorgang) :-
+	Vorgang = [_, [Operation, _], _, [_, _]],
+	rezept:wandelAktion(Operation, _),
+	!.
 	

--- a/sammeln.pl
+++ b/sammeln.pl
@@ -577,7 +577,6 @@ minenLaserNutzen(diWasserStoff, 4).
 minenLaserNutzen(ferritStaub, 3).
 minenLaserNutzen(gammaWurzel, 4).
 minenLaserNutzen(geode, 0).
-minenLaserNutzen(kelpBeutel, 20).
 minenLaserNutzen(kristallFragment, 0).
 minenLaserNutzen(kobalt, 4).
 minenLaserNutzen(kohlenStoff, 2).
@@ -587,7 +586,6 @@ minenLaserNutzen(pilzSchimmel, 1).
 minenLaserNutzen(sauerStoff, 9).
 minenLaserNutzen(sternenKnolle, 0).
 minenLaserNutzen(stickStoff, 9).
-minenLaserNutzen(sturmKristall, 0).
 
 /* mit Terrainformer abbauen */
 terrainFormerNutzen(aktiviertesCadmium, 0).

--- a/spielStatus.pl
+++ b/spielStatus.pl
@@ -6,7 +6,7 @@
 
 /* Spielkonditionen */
 /* Sammelmöglichkeiten */
-spielStatusInit :- 
+spielStatusInit :-  
 	abolish(spielerStatus/1)
 	,assertz(spielStatus(minenLaser))
 	,assertz(spielStatus(verbesserterMinenLaser))
@@ -45,7 +45,7 @@ spielStatusInit :-
 	,assertz(systemAusstattung(['System', 'MeinPlanet', ortBasis], 2400))
 	,assertz(systemAusstattung(['System', 'MeinPlanet', ortSpieler], 0))
 	,abolish(vorhaben/4)
-	,assertz(vorhaben('System', 'MeinPlanet', bauen, ortHauptBasis))
+	,assertz(vorhaben('System', 'MeinPlanet', bauen, ortWasser))
 	.
 
 

--- a/suchAlgorithmus.pl
+++ b/suchAlgorithmus.pl
@@ -12,11 +12,15 @@ baueFuerVorfertigung(Anzahl, Stoff) :-
 	statistik:bildeGesamtZahl(SammelSet, 0, GesamtZahl),
 	statistik:bildeGesamtWert(SammelSet, 0, GesamtWertSammlung),
 	statistik:bildeGesamtHauptZeitAufwand(Vorgaenge, 0, GesamtSammelZeitAufwand),
+	logistik:logistikOptimierungReisen(Vorgaenge, OptimierteVorgaenge),
+	reisen:bildeReiseZeiten(OptimierteVorgaenge, ReiseZeit),
+	arbeitsVorbereitung:bildeNebenZeiten(OptimierteVorgaenge, NebenZeit),
 	statistik:bildeGesamtAufwaende(Vorgaenge, 0, GesamtEinkaufsAufwand),
+	GesamtZeitAufwand is GesamtSammelZeitAufwand + NebenZeit + ReiseZeit, 
 	GesamtAufwand is GesamtEinkaufsAufwand,
 	ausgangsStoff:stoff(Stoff, Wert),
 	Erloes is Anzahl * Wert,
-	assertz(loesung(Stoff, Vorgaenge, SammelSet, GesamtZahl, GesamtWertSammlung, GesamtSammelZeitAufwand, GesamtAufwand, Erloes)),
+	assertz(loesung(Stoff, Vorgaenge, SammelSet, GesamtZahl, GesamtWertSammlung, GesamtZeitAufwand, GesamtAufwand, Erloes)),
 	fail.
 
 /* Subprädikate */
@@ -32,13 +36,13 @@ baue(Anzahl, Stoff) :-
 	statistik:bildeGesamtHauptZeitAufwand(Vorgaenge, 0, GesamtSammelZeitAufwand),
 	logistik:logistikOptimierungReisen(Vorgaenge, OptimierteVorgaenge),
 	reisen:bildeReiseZeiten(OptimierteVorgaenge, ReiseZeit),
-	reisen:fuegeReiseOperationenEin(OptimierteVorgaenge, ortSpieler, [], ErgaenzteVorgaenge),
-	arbeitsVorbereitung:bildeNebenZeiten(ErgaenzteVorgaenge, NebenZeit),
-	statistik:bildeGesamtAufwaende(ErgaenzteVorgaenge, 0, GesamtEinkaufsAufwand),
+	arbeitsVorbereitung:bildeNebenZeiten(OptimierteVorgaenge, NebenZeit),
+	statistik:bildeGesamtAufwaende(OptimierteVorgaenge, 0, GesamtEinkaufsAufwand),
 	GesamtZeitAufwand is GesamtSammelZeitAufwand + NebenZeit + ReiseZeit, 
 	GesamtAufwand is GesamtEinkaufsAufwand,
 	ausgangsStoff:stoff(Stoff, Wert),
 	Erloes is Anzahl * Wert,
+	reisen:fuegeReiseOperationenEin(OptimierteVorgaenge, ortSpieler, [], ErgaenzteVorgaenge),
 	assertz(loesung(Stoff, ErgaenzteVorgaenge, SammelSet, GesamtZahl, GesamtWertSammlung, GesamtZeitAufwand, GesamtAufwand, Erloes)),
 	fail.
 


### PR DESCRIPTION
ausgabe: auf dreispaltig mit Operation gegangen
logistik: gruppierung nach gleichen Zielstoffen und nach Ort.
reisen: orte konsistent mit chackfunktion, größte nötige Raffinerie eines Gesamtablaufs kann bestimmt werden, Regel, dass nur an einer Raffinerie gearbeitet wird.
sammeln: Korrekturen
spielStatus: Teständerungen
suchalgorithmus: ReiseSchritte werden erst am Ende eingefügt.