### PR TITLE
20005 EIgenschaften Himmelskörper Maske

### DIFF
--- a/load.pl
+++ b/load.pl
@@ -20,5 +20,7 @@
 :-	use_module('D:/Andi/Documents/Projekte/Prolog/NoMansSkyTrainer/ausgabe').
 :-	use_module('D:/Andi/Documents/Projekte/Prolog/NoMansSkyTrainer/server').
 :-	use_module('D:/Andi/Documents/Projekte/Prolog/NoMansSkyTrainer/stoffErlangenDialog').
-:-	use_module('D:/Andi/Documents/Projekte/Prolog/NoMansSkyTrainer/planetenNamenDialog').
+:-	use_module('D:/Andi/Documents/Projekte/Prolog/NoMansSkyTrainer/systemNamenDialog').
+:-	use_module('D:/Andi/Documents/Projekte/Prolog/NoMansSkyTrainer/planetMondNameDialog').
+:-	use_module('D:/Andi/Documents/Projekte/Prolog/NoMansSkyTrainer/planetenEigenschaftenDialog').
 :-	use_module('D:/Andi/Documents/Projekte/Prolog/NoMansSkyTrainer/main').

--- a/planetMondNameDialog.pl
+++ b/planetMondNameDialog.pl
@@ -1,4 +1,4 @@
-:- module(planetMondNameDialog, [planetMondNameDialog/1]).
+:- module(planetMondNameDialog, [planetMondNameDialog/1, planetMondName/1]).
 
 :- use_module(library(dcg/basics)).
 :- use_module(library(http/thread_httpd)).
@@ -13,7 +13,7 @@
 
 planetMondNameDialog(_Request) :-
 	findall(System, spielStatus:systeme(System, _), Systeme),
-	server:baueOptionsFeld('auswahlSystem', Systeme, OptionList),
+	server:baueOptionsFeld('auswahlSystem', Systeme, 1, OptionList),
 	TermerizedBody = [
 		\['<header>'],
 	    h1([align(center)], ['Eigenschaften Sternensystem eingeben']),
@@ -64,7 +64,7 @@ planetMondName(Request) :-
      planet4(Planet4, [default('')]), mond1(Mond4, [default('')]),
      planet5(Planet5, [default('')]), mond1(Mond5, [default('')])
     ]),
-    abolish(spielStatus:planeten/2),
+    spielStatus:initPlaneten,
     (Planet1 = ''; assertz(spielStatus:planeten(AuswahlSystem, Planet1))),
     (Planet2 = ''; assertz(spielStatus:planeten(AuswahlSystem, Planet2))),
     (Planet3 = ''; assertz(spielStatus:planeten(AuswahlSystem, Planet3))),

--- a/planetenEigenschaftenDialog.pl
+++ b/planetenEigenschaftenDialog.pl
@@ -1,0 +1,466 @@
+:- module(planetenEigenschaftenDialog, [planetenEigenschaftenDialogSystemAuswahl/1]).
+
+:- use_module(library(dcg/basics)).
+:- use_module(library(http/thread_httpd)).
+:- use_module(library(http/http_dispatch)).
+:- use_module(library(http/http_error)).
+:- use_module(library(http/html_write)).
+:- use_module(library(http/http_parameters)).
+
+:- http_handler('/planetenEigenschaftenDialogSystemAuswahl', planetenEigenschaftenDialogSystemAuswahl, []).
+:- http_handler('/planetenEigenschaftenDialogPlanetAuswahl', planetenEigenschaftenDialogPlanetAuswahl, []).
+:- http_handler('/planetenEigenschaftenDialog', planetenEigenschaftenDialog, []).
+:- http_handler('/planetenEigenschaften', planetenEigenschaften, []).
+
+/* -----------------------------------  Systemauswahl ----------------------------------------------- */
+planetenEigenschaftenDialogSystemAuswahl(_Request) :-
+	/* findall(System, (spielStatus:systeme(System, _), System \= 'System'), Systeme),*/
+	findall(System, (spielStatus:systeme(System, _) ), Systeme),
+	server:baueOptionsFeld('auswahlSystem', Systeme, 2, OptionList),
+	TermerizedBody = [
+		\['<header>'],
+	    h1([align(center)], ['Eigenschaften Himmelskörper eingeben: Systemauswahl']),
+	    \['</header>'],
+		\['<formSpace>'],       
+	    form([action('/planetenEigenschaftenDialogPlanetAuswahl'), method('post'), name('planetenEigenschaftenAuswahlSystemForm')], 
+	       	 [h3('Sternensystem'),
+	       	  \eingabeTabelle(OptionList),
+	       	  p(table([width("12%"), border("0"), cellspacing("3"), cellpadding("2")],
+			    	  [td([button([name("submit"), type("submit")], 'OK')]),
+			    	   td([button([name("reset"), type("reset")], 'reset')])
+			    	  ]))    
+			 ]),
+		\['</formSpace>']
+		             ],       
+	server:holeCssAlsStyle(StyleString),
+	TermerizedHead = [\[StyleString], title('planetMondNameDialog')],
+	reply_html_page(TermerizedHead, TermerizedBody).
+
+eingabeTabelle(OptionList) -->
+	html(
+   	  div(class('table30'),[
+   	    div(class('tr'), [
+   	  	    div(class('td'), [
+   	  	  	label([for('auswahlSystem')],'System: '),
+   	  	  	\OptionList
+   	  	    ]) 
+   	  	])
+   	  ])).
+
+
+/* -----------------------------------  Planetauswahl ----------------------------------------------- */
+planetenEigenschaftenDialogPlanetAuswahl(Request) :-
+	member(method(post), Request), !,
+	http_parameters(Request, 
+	[auswahlSystem(AuswahlSystem, [length > 0])]),
+	((AuswahlSystem = 'Bitte wählen', fehlerBehandlung); 
+	(
+	 findall(Planet, spielStatus:planeten(AuswahlSystem, Planet), Planeten),
+	 server:baueOptionsFeld('auswahlPlanet', Planeten, 2, OptionList),
+	
+	 TermerizedBody = [
+	 \['<header>'],
+     h1([align(center)], ['Eigenschaften Himmelskörper eingeben']),
+     \['</header>'],
+	 \['<formSpace>'],       
+     form([action('/planetenEigenschaftenDialog'), method('post'), name('planetenEigenschaftenAuswahlPlanetForm')], 
+       	 [h3('Auswahl Himmelskörper'),
+       	  \eingabeTabelle(AuswahlSystem, OptionList),
+       	  p(table([width("12%"), border("0"), cellspacing("3"), cellpadding("2")],
+		    	  [td([button([name("submit"), type("submit")], 'OK')]),
+		    	   td([button([name("reset"), type("reset")], 'reset')])
+		    	  ]))    
+		 ]),
+	 \['</formSpace>']
+		             ],       
+	 server:holeCssAlsStyle(StyleString),
+	 TermerizedHead = [\[StyleString], title('planetMondNameDialog')],
+	 reply_html_page(TermerizedHead, TermerizedBody)
+	)).
+
+eingabeTabelle(AuswahlSystem, OptionList) -->
+	html(
+   	  div(class('table50'),[
+   	    div(class('tr'), [
+   	    	\divInputReadOnly('auswahlSystem', 'System: ', AuswahlSystem, 1),
+   	  	    div(class('td'), [
+   	  	  	label([for('planetenName')],'Planet: '),
+   	  	  	\OptionList
+   	  	    ]) 
+   	  	])
+   	  ])).
+   	  
+	
+/* -----------------------------------  Eigenschaften eingeben -------------------------------------- */
+planetenEigenschaftenDialog(Request) :-
+	member(method(post), Request), !,
+	http_parameters(Request, 
+	[auswahlSystem(AuswahlSystem, [length > 0]),
+	 auswahlPlanet(AuswahlPlanet, [length > 0])
+	]),
+	(AuswahlPlanet = 'Bitte wählen' -> fehlerBehandlung; 
+	 planetenEigenschaftenAnzeigen(AuswahlSystem, AuswahlPlanet
+	)).
+
+planetenEigenschaftenAnzeigen(AuswahlSystem, AuswahlPlanet) :-
+	/* Einlesen vorhandener Werte */
+	((spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortHauptBasis], 0) -> HauptBasisVorhandenVal=true; HauptBasisVorhandenVal=false),
+	 (spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortWasser], WasserEntfernungValNum) -> WasserVorhandenVal=true; WasserVorhandenVal=false),
+	 (spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortAussenPosten], AussenPostenEntfernungValNum) -> AussenPostenVorhandenVal=true; AussenPostenVorhandenVal=false),
+	 (spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortRaumStation], RaumstationEntfernungValNum) -> RaumstationVorhandenVal=true; RaumstationVorhandenVal=false),
+	 
+	 (spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortMittlereRaffinerie], MittlereRaffinerieEntfernungValNum) -> MittlereRaffinerieVorhandenVal=true; MittlereRaffinerieVorhandenVal=false),
+	 (spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortGrosseRaffinerie], GrosseRaffinerieEntfernungValNum) -> GrosseRaffinerieVorhandenVal=true; GrosseRaffinerieVorhandenVal=false),
+	 (spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortHandelsTerminal], HandelsTerminalEntfernungValNum) -> HandelsTerminalVorhandenVal=true; HandelsTerminalVorhandenVal=false),
+	 (spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortKleineRaffinerie], KleineRaffinerieEntfernungValNum) -> KleineRaffinerieVorhandenVal=true; KleineRaffinerieVorhandenVal=false),
+	 (spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortNahrungsProzessor], NahrungsProzessorEntfernungValNum) -> NahrungsProzessorVorhandenVal=true; NahrungsProzessorVorhandenVal=false),
+	 (spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortBasisTerminus], BasisTerminusEntfernungValNum) -> BasisTerminusVorhandenVal=true; BasisTerminusVorhandenVal=false),
+	 (spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortForschungsTerminal], ForschungsTerminalEntfernungValNum) -> ForschungsTerminalVorhandenVal=true; ForschungsTerminalVorhandenVal=false),
+	 (spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortAthmosphaerenAnlageSauerStoff], AthmosphaerenAnlageSauerStoffEntfernungValNum) -> AthmosphaerenAnlageSauerStoffVal=true; AthmosphaerenAnlageSauerStoffVal=false),
+	 (spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortAthmosphaerenAnlageStickStoff], AthmosphaerenAnlageStickStoffEntfernungValNum) -> AthmosphaerenAnlageStickStoffVorhandenVal=true; AthmosphaerenAnlageStickStoffVorhandenVal=false)
+	),
+	(var(WasserEntfernungValNum) -> WasserEntfernungVal = 'Zeit'; number_string(WasserEntfernungValNum, WasserEntfernungVal)),
+	(var(AussenPostenEntfernungValNum) -> AussenPostenEntfernungVal = 'Zeit'; number_string(AussenPostenEntfernungValNum, AussenPostenEntfernungVal)),
+	(var(RaumstationEntfernungValNum) -> RaumstationEntfernungVal = 'Zeit'; number_string(RaumstationEntfernungValNum, RaumstationEntfernungVal)),
+	(var(MittlereRaffinerieEntfernungValNum) -> MittlereRaffinerieEntfernungVal = 'Zeit'; number_string(MittlereRaffinerieEntfernungValNum, MittlereRaffinerieEntfernungVal)),
+	(var(GrosseRaffinerieEntfernungValNum) -> GrosseRaffinerieEntfernungVal = 'Zeit'; number_string(GrosseRaffinerieEntfernungValNum, GrosseRaffinerieEntfernungVal)),
+	(var(HandelsTerminalEntfernungValNum) -> HandelsTerminalEntfernungVal = 'Zeit'; number_string(HandelsTerminalEntfernungValNum, HandelsTerminalEntfernungVal)),
+	(var(KleineRaffinerieEntfernungValNum) -> KleineRaffinerieEntfernungVal = 'Zeit'; number_string(KleineRaffinerieEntfernungValNum, KleineRaffinerieEntfernungVal)),
+	(var(NahrungsProzessorEntfernungValNum) -> NahrungsProzessorEntfernungVal = 'Zeit'; number_string(NahrungsProzessorEntfernungValNum, NahrungsProzessorEntfernungVal)),
+	(var(BasisTerminusEntfernungValNum) -> BasisTerminusEntfernungVal = 'Zeit'; number_string(BasisTerminusEntfernungValNum, BasisTerminusEntfernungVal)),
+	(var(ForschungsTerminalEntfernungValNum) -> ForschungsTerminalEntfernungVal = 'Zeit'; number_string(ForschungsTerminalEntfernungValNum, ForschungsTerminalEntfernungVal)),
+	(var(AthmosphaerenAnlageSauerStoffEntfernungValNum) -> AthmosphaerenAnlageSauerStoffEntfernungVal = 'Zeit'; number_string(AthmosphaerenAnlageSauerStoffEntfernungValNum, AthmosphaerenAnlageSauerStoffEntfernungVal)),
+	(var(AthmosphaerenAnlageStickStoffEntfernungValNum) -> AthmosphaerenAnlageStickStoffEntfernungVal = 'Zeit'; number_string(AthmosphaerenAnlageStickStoffEntfernungValNum, AthmosphaerenAnlageStickStoffEntfernungVal)),
+
+	TermerizedBody = [
+	\['<header>'],
+    h1([align(center)], ['Eigenschaften Himmelskörper eingeben']),
+    \['</header>'],
+	\['<formSpace>'],       
+    form([action('/planetenEigenschaften'), method('post'), name('planetenEigenschaftenVorauswahlForm')], 
+       	 [h3('Auswahl Himmelskörper'),
+       	  \eingabeTabelleReadOnly(AuswahlSystem, AuswahlPlanet),
+       	  h3('Einrichtungen und ihre Reisezeit von der Hauptbasis'),
+	      h4('Jeweils die Einrichtung mit der kürzesten Entfernung zur Hauptbasis angeben!'),
+       	  \tabelleEinrichtungen(
+			HauptBasisVorhandenVal,
+			WasserVorhandenVal, WasserEntfernungVal,
+			AussenPostenVorhandenVal, AussenPostenEntfernungVal, 
+			RaumstationVorhandenVal, RaumstationEntfernungVal,
+			MittlereRaffinerieVorhandenVal, MittlereRaffinerieEntfernungVal,
+			GrosseRaffinerieVorhandenVal, GrosseRaffinerieEntfernungVal,
+			HandelsTerminalVorhandenVal, HandelsTerminalEntfernungVal,
+			KleineRaffinerieVorhandenVal, KleineRaffinerieEntfernungVal,
+			NahrungsProzessorVorhandenVal, NahrungsProzessorEntfernungVal,
+			BasisTerminusVorhandenVal, BasisTerminusEntfernungVal,
+			ForschungsTerminalVorhandenVal, ForschungsTerminalEntfernungVal,
+			AthmosphaerenAnlageSauerStoffVal, AthmosphaerenAnlageSauerStoffEntfernungVal,
+			AthmosphaerenAnlageStickStoffVorhandenVal, AthmosphaerenAnlageStickStoffEntfernungVal
+       	  ),
+       	  p(table([width("12%"), border("0"), cellspacing("3"), cellpadding("2")],
+		    	  [td([button([name("submit"), type("submit")], 'OK')]),
+		    	   td([button([name("reset"), type("reset")], 'reset')])
+		    	  ]))    
+		 ]),
+	\['</formSpace>']		             ],       
+	server:holeCssAlsStyle(StyleString),
+	TermerizedHead = [\[StyleString], title('planetMondNameDialog')],
+	reply_html_page(TermerizedHead, TermerizedBody).
+
+
+eingabeTabelleReadOnly(AuswahlSystem, AuswahlPlanet) -->
+	html(
+   	  div(class('table50'),[
+   	    div(class('tr'), [
+   	    	\divInputReadOnly('auswahlSystem', 'System: ', AuswahlSystem, 1),
+   	    	\divInputReadOnly('auswahlPlanet', 'Planet: ', AuswahlPlanet, 2)
+   	  	])
+   	  ])).
+
+divInputReadOnly(Name, LabelText, Value, Index) -->
+	html(
+	div(class('td'), [
+		label([ for(Name)],[LabelText]),
+   	  	input([ name(Name),
+   	  	  		type('text'), 
+   	  	  		size(20), 
+   	  	  		maxlength(20),
+   	  	  		value(Value),
+   	  	  		tabindex(Index),
+   	  	  		readonly(true)
+   	  	  	  ])
+   	  	])
+	).
+
+tabelleEinrichtungen(
+	HauptBasisVorhandenVal,
+	WasserVorhandenVal, WasserEntfernungVal,
+	AussenPostenVorhandenVal, AussenPostenEntfernungVal, 
+	RaumstationVorhandenVal, RaumstationEntfernungVal,
+	MittlereRaffinerieVorhandenVal, MittlereRaffinerieEntfernungVal,
+	GrosseRaffinerieVorhandenVal, GrosseRaffinerieEntfernungVal,
+	HandelsTerminalVorhandenVal, HandelsTerminalEntfernungVal,
+	KleineRaffinerieVorhandenVal, KleineRaffinerieEntfernungVal,
+	NahrungsProzessorVorhandenVal, NahrungsProzessorEntfernungVal,
+	BasisTerminusVorhandenVal, BasisTerminusEntfernungVal,
+	ForschungsTerminalVorhandenVal, ForschungsTerminalEntfernungVal,
+	AthmosphaerenAnlageSauerStoffVal, AthmosphaerenAnlageSauerStoffEntfernungVal,
+	AthmosphaerenAnlageStickStoffVorhandenVal, AthmosphaerenAnlageStickStoffEntfernungVal
+    ) -->
+	html(div(class('table50'),[
+   	    div(class('tr'), [
+   	    	div(class('th'), 'Hauptbasis'),
+			div(class('td'), [
+				\check('hauptBasis_vorhanden', HauptBasisVorhandenVal, 101),
+	   	  	    input([	type('text'), 
+	   	  	    		value('0'), 
+	   	  	    		size(6), 
+	   	  	    		minlength(1), 
+	   	  	    		maxlength(6), 
+	   	  	    		pattern('(^[1..9]*[0-9]*$)|Zeit'),
+	   	  	    		name('hauptBasis_entfernung'),
+	   	  	    		tabindex(102),
+	   	  	    		disabled(true)
+	   	  	    	  ]),
+	   	  	   label([for('hauptBasis_entfernung')],[' 1/100 sec'])
+			])
+   	  	]),
+   	    div(class('tr'), [
+   	    	div(class('th'), 'Wasser'),
+   	    	\checkZeitUnitGruppe('wasser_vorhanden', WasserVorhandenVal, 102, 'wasser_entfernung', WasserEntfernungVal, 103)
+   	  	]),
+   	    div(class('tr'), [
+   	    	div(class('th'), 'Außenposten'),
+   	    	\checkZeitUnitGruppe('aussenPosten_vorhanden', AussenPostenVorhandenVal, 104, 'aussenPosten_entfernung', AussenPostenEntfernungVal, 105)
+   	  	]),
+   	    div(class('tr'), [
+   	    	div(class('th'), 'Raumstation'),
+   	    	\checkZeitUnitGruppe('raumstation_vorhanden', RaumstationVorhandenVal, 106, 'raumstation_entfernung', RaumstationEntfernungVal, 107)
+   	  	]),
+  	    div(class('tr'), [
+   	    	div(class('th'), 'Mittlere Raffinerie'),
+   	    	\checkZeitUnitGruppe('mittlereRaffinerie_vorhanden', MittlereRaffinerieVorhandenVal, 108, 'mittlereRaffinerie_entfernung', MittlereRaffinerieEntfernungVal, 109)
+   	    ]),
+    	    div(class('tr'), [
+   	    	div(class('th'), 'Große Raffinerie'),
+   	    	\checkZeitUnitGruppe('grosseRaffinerie_vorhanden', GrosseRaffinerieVorhandenVal, 110, 'grosseRaffinerie_entfernung', GrosseRaffinerieEntfernungVal, 111)
+   	    ]),
+   	    div(class('tr'), [
+   	    	div(class('th'), 'Handelsterminal'),
+   	    	\checkZeitUnitGruppe('handelsTerminal_vorhanden', HandelsTerminalVorhandenVal, 112, 'handelsTerminal_entfernung', HandelsTerminalEntfernungVal, 113)
+   	    ]),
+   	  	div(class('tr'), [
+   	    	div(class('th'), 'kleine Raffinerie'),
+   	    	\checkZeitUnitGruppe('raffinerieKlein_vorhanden', KleineRaffinerieVorhandenVal, 301, 'raffinerieKlein_entfernung', KleineRaffinerieEntfernungVal, 302)
+   	  	]),
+   	  	div(class('tr'), [
+   	    	div(class('th'), 'Nahrungsprozessor'),
+   	    	\checkZeitUnitGruppe('nahrungsProzessor_vorhanden', NahrungsProzessorVorhandenVal, 303, 'nahrungsProzessor_entfernung', NahrungsProzessorEntfernungVal, 304)
+   	  	]),
+   	  	div(class('tr'), [
+   	    	div(class('th'), 'Basisterminus'),
+   	    	\checkZeitUnitGruppe('basisTerminus_vorhanden', BasisTerminusVorhandenVal, 307, 'basisTerminus_entfernung', BasisTerminusEntfernungVal, 308)
+   	  	]),
+   	  	div(class('tr'), [
+   	    	div(class('th'), 'Konstruktionsforschungsstation'),
+   	    	\checkZeitUnitGruppe('konstruktionsStation_vorhanden', ForschungsTerminalVorhandenVal, 309, 'konstruktionsStation_entfernung', ForschungsTerminalEntfernungVal, 310)
+   	  	]),
+   	  	div(class('tr'), [
+   	    	div(class('th'), 'Atmosphaerenanlage Sauerstoff'),
+   	    	\checkZeitUnitGruppe('atmosphaerenAnlageSauerStoff_vorhanden', AthmosphaerenAnlageSauerStoffVal, 311, 'atmosphaerenAnlageSauerStoff_entfernung', AthmosphaerenAnlageSauerStoffEntfernungVal, 312)
+   	  	]),
+   	  	div(class('tr'), [
+   	    	div(class('th'), 'Atmosphaerenanlage Stickstoff'),
+   	    	\checkZeitUnitGruppe('atmosphaerenAnlageStickStoff_vorhanden', AthmosphaerenAnlageStickStoffVorhandenVal, 313, 'atmosphaerenAnlageStickStoff_entfernung', AthmosphaerenAnlageStickStoffEntfernungVal, 314)
+   	  	])
+   	  ])).
+
+checkZeitUnitGruppe(NameCheck, ValueCheck, IndexCheck, NameZeit, ValueZeit, IndexZeit) -->
+	html(   	  	    
+		div(class('td'), [
+			\check(NameCheck, ValueCheck, IndexCheck),
+   	  	    input([	type('text'), 
+   	  	    		size(6), 
+   	  	    		minlength(1), 
+   	  	    		maxlength(6), 
+   	  	    		pattern('(^[1..9]*[0-9]*$)|Zeit'),
+   	  	    		name(NameZeit),
+   	  	    		value(ValueZeit),
+   	  	    		tabindex(IndexZeit)
+   	  	    	  ]),
+   	  	   label([for(NameZeit)],[' 1/100 sec'])
+		])
+	).
+
+check(CheckName, CheckVal, Index) -->
+	 { string_concat('<input type="checkbox" name=', CheckName, CheckedString0),
+	   string_concat(CheckedString0, ' tabindex=', CheckedString1),
+	   string_concat(CheckedString1, Index, CheckedString2),
+	   ((CheckVal = true, string_concat(CheckedString2, ' checked>', CheckedString));
+	    (CheckVal = false, string_concat(CheckedString2, '>', CheckedString))
+	   )
+	 },
+	 html(
+	 	\[CheckedString]
+  	).
+
+/* -----------------------------------  Abspeichern und Antwort ------------------------------------- */
+planetenEigenschaften(Request) :-
+	member(method(post), Request), !,
+	http_parameters(Request, 
+	[auswahlSystem(AuswahlSystem, [length > 0]),
+	 auswahlPlanet(AuswahlPlanet, [length > 0]),
+	 
+     hauptBasis_vorhanden(HauptBasisVorhanden, [default(off)]),
+     wasser_vorhanden(WasserVorhanden, [default(off)]),
+     aussenPosten_vorhanden(AussenPostenVorhanden, [default(off)]),
+     raumstation_vorhanden(RaumstationVorhanden, [default(off)]),
+     
+     raffinerieMittel_vorhanden(RaffinerieMittelVorhanden, [default(off)]),
+     raffinerieGross_vorhanden(RaffinerieGrossVorhanden, [default(off)]),
+     handelsTerminal_vorhanden(HandelsTerminalVorhanden, [default(off)]),
+     
+     raffinerieKlein_vorhanden(RaffinerieKleinVorhanden, [default(off)]),
+     nahrungsProzessor_vorhanden(NahrungsProzessorVorhanden, [default(off)]),
+     basisTerminus_vorhanden(BasisTerminusVorhanden, [default(off)]),
+     konstruktionsStation_vorhanden(KonstruktionsStationVorhanden, [default(off)]),
+	 atmosphaerenAnlageSauerStoff_vorhanden(AtmosphaerenAnlageSauerStoffVorhanden, [default(off)]),
+	 atmosphaerenAnlageStickStoff_vorhanden(AtmosphaerenAnlageStickStoffVorhanden, [default(off)]),
+
+     wasser_entfernung(WasserEntfernung, [default(0)]), 
+     aussenPosten_entfernung(AussenPostenEntfernung, [default(0)]),
+     raumstation_entfernung(RaumstationEntfernung, [default(0)]), 
+	 raffinerieMittel_entfernung(RaffinerieMittelEntfernung, [default(0)]),
+	 raffinerieGross_entfernung(RaffinerieGrossEntfernung, [default(0)]),
+	 handelsTerminal_entfernung(HandelsTerminalEntfernung, [default(0)]),
+	 
+     raffinerieKlein_entfernung(RaffinerieKleinEntfernung, [default(0)]),
+     nahrungsProzessor_entfernung(NahrungsProzessorEntfernung, [default(0)]), 
+     basisTerminus_entfernung(BasisTerminusEntfernung, [default(0)]), 
+     konstruktionsStation_entfernung(KonstruktionsStationEntfernung, [default(0)]),
+     atmosphaerenAnlageSauerStoff_entfernung(AtmosphaerenAnlageSauerStoffEntfernung, [default(0)]),
+     atmosphaerenAnlageStickStoff_entfernung(AtmosphaerenAnlageStickStoffEntfernung, [default(0)])
+    ]),
+    ((WasserVorhanden = on, WasserEntfernung = 'Zeit', fehlerBehandlungGruppe('Wasser'));
+     (AussenPostenVorhanden = on, AussenPostenEntfernung = 'Zeit', fehlerBehandlungGruppe('AussenPosten'));
+     (RaumstationVorhanden = on, RaumstationEntfernung = 'Zeit', fehlerBehandlungGruppe('Raumstation'));
+     (RaffinerieMittelVorhanden = on, RaffinerieMittelEntfernung = 'Zeit', fehlerBehandlungGruppe('mittlere Raffinerie'));
+     (RaffinerieGrossVorhanden = on, RaffinerieGrossEntfernung = 'Zeit', fehlerBehandlungGruppe('große Raffinerie'));
+     (HandelsTerminalVorhanden = on, HandelsTerminalEntfernung = 'Zeit', fehlerBehandlungGruppe('Handelsterminal'));
+     (RaffinerieKleinVorhanden = on, RaffinerieKleinEntfernung = 'Zeit', fehlerBehandlungGruppe('kleine Raffinerie'));
+     (NahrungsProzessorVorhanden = on, NahrungsProzessorEntfernung = 'Zeit', fehlerBehandlungGruppe('Nahrungsprozessor'));
+     (BasisTerminusVorhanden = on, BasisTerminusEntfernung = 'Zeit', fehlerBehandlungGruppe('Basisterminus'));
+     (KonstruktionsStationVorhanden = on, KonstruktionsStationEntfernung = 'Zeit', fehlerBehandlungGruppe('Konstruktionsstation'));
+     (AtmosphaerenAnlageSauerStoffVorhanden = on, AtmosphaerenAnlageSauerStoffEntfernung = 'Zeit', fehlerBehandlungGruppe('Atmosphaerenanlagesauerstoff'));
+     (AtmosphaerenAnlageStickStoffVorhanden = on, AtmosphaerenAnlageStickStoffEntfernung = 'Zeit', fehlerBehandlungGruppe('Atmosphaerenanlagestickstoff'));
+     (HauptBasisVorhanden = off,
+      WasserVorhanden = off,
+      AussenPostenVorhanden = off,
+      RaumstationVorhanden = off,
+      RaumstationVorhanden = off,
+      RaffinerieMittelVorhanden = off,
+      RaffinerieGrossVorhanden = off,
+      HandelsTerminalVorhanden = off,
+      RaffinerieKleinVorhanden = off,
+      NahrungsProzessorVorhanden = off,
+      BasisTerminusVorhanden = off,
+      KonstruktionsStationVorhanden = off,
+      AtmosphaerenAnlageSauerStoffVorhanden = off,
+      AtmosphaerenAnlageStickStoffVorhanden = off,
+      ignore(retractall(spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, _], _))),
+      gespeichert
+     );
+     (  
+      ((WasserEntfernung \= 'Zeit', atom_number(WasserEntfernung, WasserEntfernungNum));
+	   (AussenPostenEntfernung \= 'Zeit', atom_number(AussenPostenEntfernung, AussenPostenEntfernungNum));
+	   (RaumstationEntfernung \= 'Zeit', atom_number(RaumstationEntfernung, RaumstationEntfernungNum));
+	   (RaffinerieMittelEntfernung \= 'Zeit', atom_number(RaffinerieMittelEntfernung, RaffinerieMittelEntfernungNum));
+	   (RaffinerieGrossEntfernung \= 'Zeit', atom_number(RaffinerieGrossEntfernung, RaffinerieGrossEntfernungNum));
+	   (HandelsTerminalEntfernung \= 'Zeit', atom_number(HandelsTerminalEntfernung, HandelsTerminalEntfernungNum));
+	   (RaffinerieKleinEntfernung \= 'Zeit', atom_number(RaffinerieKleinEntfernung, RaffinerieKleinEntfernungNum));
+	   (NahrungsProzessorEntfernung \= 'Zeit', atom_number(NahrungsProzessorEntfernung, NahrungsProzessorEntfernungNum));
+	   (BasisTerminusEntfernung \= 'Zeit', atom_number(BasisTerminusEntfernung, BasisTerminusEntfernungNum));
+	   (KonstruktionsStationEntfernung \= 'Zeit', atom_number(KonstruktionsStationEntfernung, KonstruktionsStationEntfernungNum));
+	   (AtmosphaerenAnlageSauerStoffEntfernung \= 'Zeit', atom_number(AtmosphaerenAnlageSauerStoffEntfernung, AtmosphaerenAnlageSauerStoffEntfernungNum));
+	   (AtmosphaerenAnlageStickStoffEntfernung \= 'Zeit', atom_number(AtmosphaerenAnlageStickStoffEntfernung, AtmosphaerenAnlageStickStoffEntfernungNum))
+	  ),
+      ignore(retractall(spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, _], _))),
+      (HauptBasisVorhanden = off; 
+       (assertz(spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortHauptBasis], 0)),
+      	assertz(spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortWald], 1500)),
+      	assertz(spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortWeltRaum], 1431)), 
+      	assertz(spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortAnomalie], 1444)) 
+      )),
+      (WasserVorhanden = off; 
+       assertz(spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortWasser], WasserEntfernungNum))
+      ),
+      (AussenPostenVorhanden = off; 
+       assertz(spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortAussenPosten], AussenPostenEntfernungNum))
+      ),
+      (RaumstationVorhanden = off; 
+       assertz(spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortRaumStation], RaumstationEntfernungNum))
+      ),
+      (RaffinerieMittelVorhanden = off; 
+       assertz(spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortMittlereRaffinerie], RaffinerieMittelEntfernungNum))
+      ),
+      (RaffinerieGrossVorhanden = off; 
+       assertz(spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortGrosseRaffinerie], RaffinerieGrossEntfernungNum))
+      ),
+      (HandelsTerminalVorhanden = off; 
+       assertz(spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortHandelsTerminal], HandelsTerminalEntfernungNum))
+      ),
+      (RaffinerieKleinVorhanden = off; 
+       assertz(spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortKleineRaffinerie], RaffinerieKleinEntfernungNum))
+      ),
+      (NahrungsProzessorVorhanden = off; 
+       assertz(spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortNahrungsProzessor], NahrungsProzessorEntfernungNum))
+      ),
+      (BasisTerminusVorhanden = off; 
+       assertz(spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortBasisTerminus], BasisTerminusEntfernungNum))
+      ),
+      (KonstruktionsStationVorhanden= off; 
+       assertz(spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortForschungsTerminal], KonstruktionsStationEntfernungNum))
+      ),
+      (AtmosphaerenAnlageSauerStoffVorhanden= off; 
+       assertz(spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortAthmosphaerenAnlageSauerStoff], AtmosphaerenAnlageSauerStoffEntfernungNum))
+      ),
+      (AtmosphaerenAnlageStickStoffVorhanden= off; 
+       assertz(spielStatus:systemAusstattung([AuswahlSystem, AuswahlPlanet, ortAthmosphaerenAnlageStickStoff], AtmosphaerenAnlageStickStoffEntfernungNum))
+      ), 
+	  gespeichert
+	)).
+	  
+	  
+gespeichert :-
+      server:holeCssAlsStyle(StyleString),
+	  TermerizedHead = [\[StyleString], title('planetMondName')],
+	  TermerizedBody = [
+		\['<header>'],
+		h3(align(center),'gespeichert!'),
+		\['</header>']
+		             ],
+	  reply_html_page(TermerizedHead, TermerizedBody).
+
+fehlerBehandlung :-
+   	server:holeCssAlsStyle(StyleString),
+	TermerizedHead = [\[StyleString], title('planetMondNameDialogErgebnis')],
+	TermerizedBody = [
+		\['<redHeader>'],
+		h3(align(center),'bitte eine Auswahl treffen!'),
+		\['</redHeader>']
+		             ],
+	reply_html_page(TermerizedHead, TermerizedBody).
+
+fehlerBehandlungGruppe(Gruppe) :-
+   	server:holeCssAlsStyle(StyleString),
+   	string_concat('Die Einrichtung ', Gruppe, FehlerMeldung0),
+   	string_concat(FehlerMeldung0, ' ist als vorhanden gekennzeichnet, aber die Zeitangabe fehlt', FehlerMeldung),
+	TermerizedHead = [\[StyleString], title('planetMondNameDialogErgebnis')],
+	TermerizedBody = [
+		\['<redHeader>'],
+		h3(align(center), FehlerMeldung),
+		\['</redHeader>']
+		             ],
+	reply_html_page(TermerizedHead, TermerizedBody).
+
+	

--- a/server.pl
+++ b/server.pl
@@ -25,6 +25,10 @@ header {
 	grid-column: 1 / 4;
 	grid-row: 1;
     }
+redHeader {
+	grid-column: 1 / 4;
+	grid-row: 1;
+    }
 formSpace {
 	grid-column: 1 / 4;
 	grid-row: 2;
@@ -47,7 +51,6 @@ formSpace,
 button1Space,
 button2Space,
 button3Space {
-
 	background: #ebf5d7;
 	border-color: #8db243;
 	border-radius: 0px 0.5em 0.5em;
@@ -55,13 +58,58 @@ button3Space {
 	padding: .5em;
 	margin: .5em;
 }
+
+redHeader {
+	background: #fbD5c7;
+	border-color: #8db243;
+	border-radius: 0px 0.5em 0.5em;
+	border: 1px solid;
+	padding: .5em;
+	margin: .5em;
+}
+
+div.table { 
+  display: table; 
+  width: calc(100% - 10px);
+	border: thin solid #999999;
+	padding: 5px;
+}
+div.table30 { 
+  display: table; 
+  width: calc(30% - 10px);
+	border: thin solid #999999;
+	padding: 5px;
+}div.table50 { 
+  display: table; 
+  width: calc(50% - 10px);
+	border: thin solid #999999;
+	padding: 5px;
+}
+div.tr { 
+  display:table-row; 
+}
+div.th { 
+  display:table-cell; 
+  border:thin solid #CCCCCC; 
+  padding:5px; 
+  font-style:normal;
+  font-variant: normal;
+  font-weight: 300;
+  font-size 18px;
+  font-family: Arial, Helvetica, sans-serif
+}
+div.td { 
+  display:table-cell; 
+  border:thin solid #CCCCCC; 
+  padding:5px; 
+}
 </style>'.
 
-baueOptionsFeld(FeldName, OptionsWerteListe, OptionList) :-
+baueOptionsFeld(FeldName, OptionsWerteListe, Index, OptionList) :-
 	ListString1 = '<select name="',
 	string_concat(ListString1, FeldName, ListString2),
-	string_concat(ListString2, '" size="1" id="', ListString3),
-	string_concat(ListString3, FeldName, ListString4),
+	string_concat(ListString2, '" size="1" tabindex="', ListString3),
+	string_concat(ListString3, Index, ListString4),
 	string_concat(ListString4, '">~n', ListString5),
 	baueOptionen(OptionsWerteListe, Optionen),
 	string_concat(ListString5, Optionen, ListString6),
@@ -83,6 +131,7 @@ baueOption(OptionsWerteSet, BisherList, NextList) :-
 	string_concat(OptionString0, '</option>', OptionString1),
 	string_concat(BisherList, OptionString1, BisherList2),
 	baueOption(Rest, BisherList2, NextList).
+
 
 dummy(_)  :-
 	format('').

--- a/spielStatus.pl
+++ b/spielStatus.pl
@@ -9,6 +9,13 @@
 /* Spielkonditionen */
 /* Sammelmöglichkeiten */
 spielStatusInit :-  
+	initSpielStatus,
+	initSysteme,
+	initPlaneten,
+	initSystemAusstattung,
+	initVorhaben.
+
+initSpielStatus :-
 	abolish(spielStatus/1)
 	,assertz(spielStatus(minenLaser))
 	,assertz(spielStatus(verbesserterMinenLaser))
@@ -27,35 +34,41 @@ spielStatusInit :-
 	,assertz(spielStatus(aussenPostenVerfügbar))
 	,assertz(spielStatus(frachterVorhanden))
 	,assertz(spielStatus(sphaereRufbar)) 
-	,assertz(spielStatus(kampfWille))
+	,assertz(spielStatus(kampfWille)).
 
-	,abolish(systeme/2)
-	,assertz(systeme('System', 'default'))
-	,abolish(planeten/2)
-	,assertz(planeten('System', 'MeinPlanet'))
+initSysteme :-
+	abolish(systeme/2)
+	,assertz(systeme('System', 'default')).
+	
+initPlaneten :-
+	abolish(planeten/2)
+	,assertz(planeten('System', 'MeinPlanet')).
+
+initSystemAusstattung :-
 	/* nur defaults Aktueller Ort kommt aus Eingabemaske */
-	,abolish(systemAusstattung/2)
+	abolish(systemAusstattung/2)
 	/* ort(<ort>, <Reisezeit von Hauptbasis in 1/100 sec>) */
-	,assertz(systemAusstattung(['System', 'MeinPlanet', ortAthmosphaerenAnlageSauerStoff], 536)) /* aus Maske */
-	,assertz(systemAusstattung(['System', 'MeinPlanet', ortAthmosphaerenAnlageStickStoff], 536)) /* aus Maske */
 	,assertz(systemAusstattung(['System', 'MeinPlanet', ortHauptBasis], 0)) /* fix */
-	,assertz(systemAusstattung(['System', 'MeinPlanet', ortBasisTerminus], 430)) /* fix */
 	,assertz(systemAusstattung(['System', 'MeinPlanet', ortWald], 1500)) /* fix */
 	,assertz(systemAusstattung(['System', 'MeinPlanet', ortWeltRaum], 1431)) /* fix */
 	,assertz(systemAusstattung(['System', 'MeinPlanet', ortAnomalie], 1444)) /* fix */
 	,assertz(systemAusstattung(['System', 'MeinPlanet', ortRaumStation], 2914)) /* fix */
+	,assertz(systemAusstattung(['System', 'MeinPlanet', ortAthmosphaerenAnlageSauerStoff], 536)) /* aus Maske */
+	,assertz(systemAusstattung(['System', 'MeinPlanet', ortAthmosphaerenAnlageStickStoff], 536)) /* aus Maske */
+	,assertz(systemAusstattung(['System', 'MeinPlanet', ortBasisTerminus], 430)) /* aus Maske */
 	,assertz(systemAusstattung(['System', 'MeinPlanet', ortWasser], 10660)) /* aus Maske */
 	,assertz(systemAusstattung(['System', 'MeinPlanet', ortAussenPosten], 11336)) /* aus Maske */
 	,assertz(systemAusstattung(['System', 'MeinPlanet', ortNahrungsProzessor], 1100)) /* aus Maske */
-	,assertz(systemAusstattung(['System', 'MeinPlanet', ortKleineRaffinerie], 1171))
-	,assertz(systemAusstattung(['System', 'MeinPlanet', ortMittlereRaffinerie], 1135)) 
-	,assertz(systemAusstattung(['System', 'MeinPlanet', ortGrosseRaffinerie], 2400))
-	,assertz(systemAusstattung(['System', 'MeinPlanet', ortHandelsTerminal], 1107))
-	,assertz(systemAusstattung(['System', 'MeinPlanet', ortForschungsTerminal], 470))
+	,assertz(systemAusstattung(['System', 'MeinPlanet', ortKleineRaffinerie], 1171)) /* aus Maske */
+	,assertz(systemAusstattung(['System', 'MeinPlanet', ortMittlereRaffinerie], 1135)) /* aus Maske */
+	,assertz(systemAusstattung(['System', 'MeinPlanet', ortGrosseRaffinerie], 2400)) /* aus Maske */
+	,assertz(systemAusstattung(['System', 'MeinPlanet', ortHandelsTerminal], 1107)) /* aus Maske */
+	,assertz(systemAusstattung(['System', 'MeinPlanet', ortForschungsTerminal], 470)) /* aus Maske */
 	,assertz(systemAusstattung(['System', 'MeinPlanet', ortFrachter], 2400)) 
-	,assertz(systemAusstattung(['System', 'MeinPlanet', ortBasis], 2400))
-	,assertz(systemAusstattung(['System', 'MeinPlanet', ortSpieler], 0))
-	,abolish(vorhaben/4)
+	,assertz(systemAusstattung(['System', 'MeinPlanet', ortSpieler], 0)).
+
+initVorhaben :-
+	abolish(vorhaben/4)
 	,assertz(vorhaben('System', 'MeinPlanet', bauen, ortWasser))
 	.
 

--- a/systemNamenDialog.pl
+++ b/systemNamenDialog.pl
@@ -137,7 +137,7 @@ systemNamen(Request) :-
       systemName319(System319, [default('')]), farbe319(Farbe319, [length > 1]),
       systemName320(System320, [default('')]), farbe320(Farbe320, [length > 1])
     ]),
-    abolish(spielStatus:systeme/2),
+    spielStatus:initSysteme,
     (System101 = ''; assertz(spielStatus:systeme(System101, Farbe101))),
     (System102 = ''; assertz(spielStatus:systeme(System102, Farbe102))),
     (System103 = ''; assertz(spielStatus:systeme(System103, Farbe103))),


### PR DESCRIPTION
load: neue Module
planetEigenschaftenDialog neu 4 Url werden bedient
planetMondNameDialog: baueOptionsfeld Schnittstellenanpassung, abolish raus
server: neues CSS Element redHeader, div tableelemente neu, baueOptionsfeld erweitert um variablen Tabindex
spielStatusInit aufgeteilt. Orte umsortiert
systemNamenDialog: abolish raus. Defaults werden erhalten