### PR TITLE
20015EinleseFunktionPlanetMondName

### DIFF
--- a/planetMondNameDialog.pl
+++ b/planetMondNameDialog.pl
@@ -26,34 +26,52 @@ planetMondNameDialog(Request) :-
 	).
 
 planetMondNameAnzeigen(AuswahlSystem) :-
+	findall(HimmelsKoerper, spielStatus:planeten(AuswahlSystem, HimmelsKoerper), HimmelsKoerperListe),
+	(nth1(1, HimmelsKoerperListe, Planet1); Planet1 = ''),
+	(nth1(2, HimmelsKoerperListe, Planet2); Planet2 = ''),
+	(nth1(3, HimmelsKoerperListe, Planet3); Planet3 = ''),
+	(nth1(4, HimmelsKoerperListe, Planet4); Planet4 = ''),
+	(nth1(5, HimmelsKoerperListe, Planet5); Planet5 = ''),
+	(nth1(6, HimmelsKoerperListe, Planet6); Planet6 = ''),
+	(nth1(7, HimmelsKoerperListe, Planet7); Planet7 = ''),
+	(nth1(8, HimmelsKoerperListe, Planet8); Planet8 = ''),
 	TermerizedBody = [
 		\['<header>'],
-	    h1([align(center)], ['Eigenschaften Sternensystem eingeben']),
+	    h1([align(center)], ['Sternensystem: Namen der Himmelskörper eingeben']),
 	    \['</header>'],
 		\['<formSpace>'],       
 	    form([action('/planetMondName'), method('post'), name('systemEigenschaftenForm')], 
 	       	 [h3('Sternensystem'),
        	  	  \eingabeTabelleReadOnly(AuswahlSystem),
-	       	  h3('Himmelskörpernamen'),
-	       	  table([width("325px"), border("1"), cellspacing("3"), cellpadding("2")],
-	       	        [tr([th([scope(col)], 'Planetenname'), 
-	       	             th([scope(col)], 'Mondname')
-	       	            ]),
-	       	         tr([td([input([name('planet1'), type('text'), class('eingabeFeld'), id('planet1'), size(20), maxlength(20)])]),
-	       	             td([input([name('mond1'), type('text'), class('eingabeFeld'), id('mond1'), size(20), maxlength(20)])])
-	       	            ]), 
-	       	         tr([td([input([name('planet2'), type('text'), class('eingabeFeld'), id('planet2'), size(20), maxlength(20)])]),
-	       	             td([input([name('mond2'), type('text'), class('eingabeFeld'), id('mond2'), size(20), maxlength(20)])])
-	       	            ]), 
-	       	         tr([td([input([name('planet3'), type('text'), class('eingabeFeld'), id('planet3'), size(20), maxlength(20)])]),
-	       	             td([input([name('mond3'), type('text'), class('eingabeFeld'), id('mond3'), size(20), maxlength(20)])])
-	       	            ]), 
-	       	         tr([td([input([name('planet4'), type('text'), class('eingabeFeld'), id('planet4'), size(20), maxlength(20)])]),
-	       	             td([input([name('mond4'), type('text'), class('eingabeFeld'), id('mond4'), size(20), maxlength(20)])])
-	       	            ]), 
-	       	         tr([td([input([name('planet5'), type('text'), class('eingabeFeld'), id('planet5'), size(20), maxlength(20)])]),
-	       	             td([input([name('mond5'), type('text'), class('eingabeFeld'), id('mond5'), size(20), maxlength(20)])])
-	       	            ]) 
+	       	  h3('Planeten und Monde'),
+	       	  div(class('table20'),
+	       	        [div(class('tr'), 
+	       	             [div([class('th'), scope("col")], 'Name') 
+	       	             ]),
+	       	         div(class('tr'), 
+	       	             [div(class('td'), [input([name('planet1'), type('text'), class('eingabeFeld'), id('planet1'), size(20), maxlength(20), value(Planet1)])])
+	       	             ]), 
+	       	         div(class('tr'), 
+	       	             [div(class('td'), [input([name('planet2'), type('text'), class('eingabeFeld'), id('planet2'), size(20), maxlength(20), value(Planet2)])])
+	       	             ]), 
+	       	         div(class('tr'), 
+	       	             [div(class('td'), [input([name('planet3'), type('text'), class('eingabeFeld'), id('planet3'), size(20), maxlength(20), value(Planet3)])])
+	       	             ]), 
+	       	         div(class('tr'), 
+	       	             [div(class('td'), [input([name('planet4'), type('text'), class('eingabeFeld'), id('planet4'), size(20), maxlength(20), value(Planet4)])])
+	       	             ]), 
+	       	         div(class('tr'), 
+	       	             [div(class('td'), [input([name('planet5'), type('text'), class('eingabeFeld'), id('planet5'), size(20), maxlength(20), value(Planet5)])])
+	       	             ]), 
+	       	         div(class('tr'), 
+	       	             [div(class('td'), [input([name('planet6'), type('text'), class('eingabeFeld'), id('planet6'), size(20), maxlength(20), value(Planet6)])])
+	       	             ]), 
+	       	         div(class('tr'), 
+	       	             [div(class('td'), [input([name('planet7'), type('text'), class('eingabeFeld'), id('planet7'), size(20), maxlength(20), value(Planet7)])])
+	       	             ]), 
+	       	         div(class('tr'), 
+	       	             [div(class('td'), [input([name('planet8'), type('text'), class('eingabeFeld'), id('planet8'), size(20), maxlength(20), value(Planet8)])])
+	       	             ]) 
 	       	        ]),
 	       	  p(table([width("12%"), border("0"), cellspacing("3"), cellpadding("2")],
 			    	  [td([button([name("submit"), type("submit")], 'OK')]),
@@ -93,11 +111,14 @@ planetMondName(Request) :-
 	member(method(post), Request), !,
 	http_parameters(Request, 
 	[auswahlSystem(AuswahlSystem, [length > 0]),
-     planet1(Planet1, [default('')]), mond1(Mond1, [default('')]),
-     planet2(Planet2, [default('')]), mond1(Mond2, [default('')]),
-     planet3(Planet3, [default('')]), mond1(Mond3, [default('')]),
-     planet4(Planet4, [default('')]), mond1(Mond4, [default('')]),
-     planet5(Planet5, [default('')]), mond1(Mond5, [default('')])
+     planet1(Planet1, [default('')]),
+     planet2(Planet2, [default('')]),
+     planet3(Planet3, [default('')]),
+     planet4(Planet4, [default('')]),
+     planet5(Planet5, [default('')]),
+     planet6(Planet6, [default('')]),
+     planet7(Planet7, [default('')]),
+     planet8(Planet8, [default('')])
     ]),
 	spielStatus:initPlaneten(AuswahlSystem),
     (Planet1 = ''; assertz(spielStatus:planeten(AuswahlSystem, Planet1))),
@@ -105,13 +126,11 @@ planetMondName(Request) :-
     (Planet3 = ''; assertz(spielStatus:planeten(AuswahlSystem, Planet3))),
     (Planet4 = ''; assertz(spielStatus:planeten(AuswahlSystem, Planet4))),
     (Planet5 = ''; assertz(spielStatus:planeten(AuswahlSystem, Planet5))),
-    (Mond1 = ''; assertz(spielStatus:planeten(AuswahlSystem, Mond1))),
-    (Mond2 = ''; assertz(spielStatus:planeten(AuswahlSystem, Mond2))),
-    (Mond3 = ''; assertz(spielStatus:planeten(AuswahlSystem, Mond3))),
-    (Mond4 = ''; assertz(spielStatus:planeten(AuswahlSystem, Mond4))),
-    (Mond5 = ''; assertz(spielStatus:planeten(AuswahlSystem, Mond5))),
+    (Planet6 = ''; assertz(spielStatus:planeten(AuswahlSystem, Planet6))),
+    (Planet7 = ''; assertz(spielStatus:planeten(AuswahlSystem, Planet7))),
+    (Planet8 = ''; assertz(spielStatus:planeten(AuswahlSystem, Planet8))),
     server:holeCssAlsStyle(StyleString),
-	TermerizedHead = [\[StyleString], title('No mans Sky trainer: Planetennamen')],
+	TermerizedHead = [\[StyleString], title('No mans Sky trainer: Himmelskörper-Namen')],
 	TermerizedBody = [
 		\['<header>'],
 		h3(align(center),'gespeichert!'),

--- a/systemNamenDialog.pl
+++ b/systemNamenDialog.pl
@@ -20,12 +20,13 @@ systemNamenDialog(_Request) :-
 	    \['</header>'],
 		\['<formSpace>'],       
 	    form([action('/systemNamen'), method('post'), id("sternenSystemEingabe")], 
-	       	 [table([width("100%"), border("1"), cellspacing("3"), cellpadding("2")],
-	       	        [tr([td(\innereTabelle(FeldNoList1)),
-	       	             td(\innereTabelle(FeldNoList2)),
-	       	             td(\innereTabelle(FeldNoList3))
-	       	            ])
-	       	        ]),
+	       	 [div(class('table'),
+	       	      [div(class('tr'), 
+	       	           [div(class('td'), \innereTabelle(FeldNoList1)),
+	       	            div(class('td'), \innereTabelle(FeldNoList2)),
+	       	            div(class('td'), \innereTabelle(FeldNoList3))
+	       	           ])
+	       	      ]),
 			    	table([width("12%"), border("0"), cellspacing("3"), cellpadding("2")],
 			    	      [td([button([name("submit"), type("submit")], 'OK')]),
 			    		   td([button([name("reset"), type("reset")], 'reset')])


### PR DESCRIPTION
planetMondNameDialog: Einlesen und auf flex Layout umgestellt, keine Unterscheidung Mond, Planet
planetSammelEigenschaftenDialog: Fehler bei leerer Maske behoben, beim Mischen der Listen muss die erste Listen nicht mehr länger sein als die zweite, TestAttribut name entfernt